### PR TITLE
added the option to give a async function for challenge validation

### DIFF
--- a/examples/offscreen-interactivity/offscreen_interactivity_tldraw/package.json
+++ b/examples/offscreen-interactivity/offscreen_interactivity_tldraw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iink-ts-with-tldraw",
-  "version": "1.0.0-buildVersion",
+  "version": "3.0.2",
   "private": false,
   "homepage": "https://myscript.github.io/iinkTS/",
   "repository": "git://github.com/MyScript/iinkTS.git",

--- a/examples/server-configuration.json
+++ b/examples/server-configuration.json
@@ -1,6 +1,6 @@
 {
   "scheme": "https",
-  "host": "cloud.preprod.myscript.com",
-  "applicationKey": "74716e99-0614-4559-abe4-300d30621808",
-  "hmacKey": "07b17879-cee0-4b0c-8ff6-23da4cbe419f"
+  "host": "cloud.myscript.com",
+  "applicationKey": "2b239721-76b1-46ed-8854-b0d1dfd7cb3b",
+  "hmacKey": "4ccabc29-03d3-4b0c-b830-7710961e5d61"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iink-ts",
-  "version": "1.0.0-buildVersion",
+  "version": "3.0.2",
   "description": "iinkTS is the fastest way to integrate handwriting panel and recognition in your webapp",
   "license": "Apache-2.0",
   "private": false,

--- a/src/recognizer/RecognizerHTTPV1.ts
+++ b/src/recognizer/RecognizerHTTPV1.ts
@@ -166,7 +166,7 @@ export class RecognizerHTTPV1
     }
     if (isVersionSuperiorOrEqual(this.configuration.server.version!, "2.0.4")) {
       headers.append("myscript-client-name", "iink-ts")
-      headers.append("myscript-client-version", "1.0.0-buildVersion")
+      headers.append("myscript-client-version", "3.0.2")
     }
     if (!isVersionSuperiorOrEqual(this.configuration.server.version!, "2.3.0")) {
       delete this.configuration.recognition.convert

--- a/src/recognizer/RecognizerHTTPV2.ts
+++ b/src/recognizer/RecognizerHTTPV2.ts
@@ -133,7 +133,7 @@ export class RecognizerHTTPV2 {
 
     if (this.configuration.server.version && isVersionSuperiorOrEqual(this.configuration.server.version, "2.0.4")) {
       headers.append("myscript-client-name", "iink-ts")
-      headers.append("myscript-client-version", "1.0.0-buildVersion")
+      headers.append("myscript-client-version", "3.0.2")
     }
 
     const reqInit: RequestInit = {

--- a/src/recognizer/RecognizerWebSocket.ts
+++ b/src/recognizer/RecognizerWebSocket.ts
@@ -217,7 +217,7 @@ export class RecognizerWebSocket
     this.#send({
       type: "authenticate",
       "myscript-client-name": "iink-ts",
-      "myscript-client-version": "1.0.0-buildVersion",
+      "myscript-client-version": "3.0.2",
     })
   }
 

--- a/src/recognizer/RecognizerWebSocket.ts
+++ b/src/recognizer/RecognizerWebSocket.ts
@@ -223,10 +223,17 @@ export class RecognizerWebSocket
 
   protected async manageHMACChallenge(hmacChallengeMessage: TRecognizerWebSocketMessageHMACChallenge): Promise<void>
   {
-    this.#send({
-      type: "hmac",
-      hmac: await computeHmac(hmacChallengeMessage.hmacChallenge, this.configuration.server.applicationKey, this.configuration.server.hmacKey)
-    })
+      if (this.configuration.server.challenge_fn) {
+          this.send({
+              type: "hmac",
+              hmac: await this.configuration.server.challenge_fn(hmacChallengeMessage.hmacChallenge, this.configuration.server.applicationKey, this.configuration.server.hmacKey)
+          })
+      } else {
+          this.send({
+              type: "hmac",
+              hmac: await computeHmac(hmacChallengeMessage.hmacChallenge, this.configuration.server.applicationKey, this.configuration.server.hmacKey)
+          })
+      }
   }
 
   protected initPing(): void

--- a/src/recognizer/RecognizerWebSocket.ts
+++ b/src/recognizer/RecognizerWebSocket.ts
@@ -226,7 +226,7 @@ export class RecognizerWebSocket
       if (this.configuration.server.challenge_fn) {
           this.send({
               type: "hmac",
-              hmac: await this.configuration.server.challenge_fn(hmacChallengeMessage.hmacChallenge, this.configuration.server.applicationKey, this.configuration.server.hmacKey)
+              hmac: await this.configuration.server.challenge_fn(hmacChallengeMessage.hmacChallenge, this.configuration.server.applicationKey)
           })
       } else {
           this.send({

--- a/src/recognizer/RecognizerWebSocketSSR.ts
+++ b/src/recognizer/RecognizerWebSocketSSR.ts
@@ -245,10 +245,18 @@ export class RecognizerWebSocketSSR
     this.#logger.info("manageAckMessage", { websocketMessage })
     const hmacChallengeMessage = websocketMessage as TRecognizerWebSocketSSRMessageHMACChallenge
     if (hmacChallengeMessage.hmacChallenge) {
-      this.send({
-        type: "hmac",
-        hmac: await computeHmac(hmacChallengeMessage.hmacChallenge, this.configuration.server.applicationKey, this.configuration.server.hmacKey)
-      })
+        if (this.configuration.server.challenge_fn) {
+            this.send({
+                type: "hmac",
+                hmac: await this.configuration.server.challenge_fn(hmacChallengeMessage.hmacChallenge, this.configuration.server.applicationKey, this.configuration.server.hmacKey)
+            })
+        } else {
+            this.send({
+                type: "hmac",
+                hmac: await computeHmac(hmacChallengeMessage.hmacChallenge, this.configuration.server.applicationKey, this.configuration.server.hmacKey)
+            })
+        }
+
     }
     if (hmacChallengeMessage.iinkSessionId) {
       this.sessionId = hmacChallengeMessage.iinkSessionId

--- a/src/recognizer/RecognizerWebSocketSSR.ts
+++ b/src/recognizer/RecognizerWebSocketSSR.ts
@@ -248,7 +248,7 @@ export class RecognizerWebSocketSSR
         if (this.configuration.server.challenge_fn) {
             this.send({
                 type: "hmac",
-                hmac: await this.configuration.server.challenge_fn(hmacChallengeMessage.hmacChallenge, this.configuration.server.applicationKey, this.configuration.server.hmacKey)
+                hmac: await this.configuration.server.challenge_fn(hmacChallengeMessage.hmacChallenge, this.configuration.server.applicationKey)
             })
         } else {
             this.send({

--- a/src/recognizer/RecognizerWebSocketSSR.ts
+++ b/src/recognizer/RecognizerWebSocketSSR.ts
@@ -134,7 +134,7 @@ export class RecognizerWebSocketSSR
     }
     if (isVersionSuperiorOrEqual(this.configuration.server.version!, "2.0.4")) {
       params["myscript-client-name"] = "iink-ts"
-      params["myscript-client-version"] = "1.0.0-buildVersion"
+      params["myscript-client-version"] = "3.0.2"
     }
     this.send(params)
   }

--- a/src/recognizer/ServerConfiguration.ts
+++ b/src/recognizer/ServerConfiguration.ts
@@ -10,6 +10,7 @@ export type TServerHTTPConfiguration = {
   scheme: TScheme,
   host: string
   applicationKey: string
+  challenge_fn?: (message: string, applicationKey: string, hmacKey: string) => Promise<string>
   hmacKey: string
   version?: string
 }

--- a/src/recognizer/ServerConfiguration.ts
+++ b/src/recognizer/ServerConfiguration.ts
@@ -10,7 +10,7 @@ export type TServerHTTPConfiguration = {
   scheme: TScheme,
   host: string
   applicationKey: string
-  challenge_fn?: (message: string, applicationKey: string, hmacKey: string) => Promise<string>
+  challenge_fn?: (message: string, applicationKey: string) => Promise<string>
   hmacKey: string
   version?: string
 }


### PR DESCRIPTION
this allows for something like this



```typescript
const challenge_fn = async (message: string, applicationKey: string) => {
    //talk to server here
    return solution
}

const editor = await iink.Editor.load(editorContainerRef.current, 'INTERACTIVEINKSSR', {
  configuration: {
    server: {
        scheme: 'https',
        host: 'cloud.myscript.com',
        applicationKey: 'your_key',
        challenge_fn 
  },
})
```

solves #10 